### PR TITLE
fix: Physics IntersectionObserver ne se déclenchait pas sur mobile

### DIFF
--- a/src/components/ui/Physics.astro
+++ b/src/components/ui/Physics.astro
@@ -468,6 +468,11 @@ const { class: className = '', dark: dark = false } = Astro.props;
     // Cleanup ancien observer
     if (observer) observer.disconnect();
 
+    // Adapter rootMargin selon la taille de l'écran
+    // Sur mobile, utiliser une marge plus petite pour éviter de bloquer le trigger
+    const isMobile = window.innerWidth < 768;
+    const rootMargin = isMobile ? '-100px 0px' : '-400px 0px';
+
     observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -478,7 +483,7 @@ const { class: className = '', dark: dark = false } = Astro.props;
           }
         });
       },
-      { threshold: 0.1, rootMargin: '-400px 0px' }
+      { threshold: 0.1, rootMargin }
     );
 
     observer.observe(container);


### PR DESCRIPTION
Le rootMargin de -400px était trop grand pour les petits écrans mobiles
(viewport ~700px), rendant impossible le trigger de la section physics.

Solution: Adapter le rootMargin dynamiquement:
- Mobile (< 768px): -100px (zone d'observation plus large)
- Desktop (>= 768px): -400px (comportement inchangé)